### PR TITLE
构建Docker镜像时锁定依赖版本

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:lts-alpine as builder
 
-ENV PROJECT_DIR=/vite-vue3-admin
+ENV PROJECT_DIR=/vite-vue3-admin/
 
 WORKDIR $PROJECT_DIR
 
@@ -8,7 +8,7 @@ WORKDIR $PROJECT_DIR
 RUN npm install -g pnpm
 
 # 安装依赖
-COPY package.json $PROJECT_DIR
+COPY package.json pnpm-lock.yaml $PROJECT_DIR
 # 若网络不通，可以使用淘宝源
 RUN pnpm config set registry https://registry.npmmirror.com
 RUN pnpm install


### PR DESCRIPTION
否则现在重新构建镜像将会出现错误
```
[unplugin-vue-define-options] unplugin-vue-define-options TypeError: Cannot read properties of undefined (reading 'scriptSetupAst')
file: /vite-vue3-admin/src/components/basic/svg-icon/svg-icon.vue
error during build:
RollupError: unplugin-vue-define-options TypeError: Cannot read properties of undefined (reading 'scriptSetupAst')
    at error (file:///vite-vue3-admin/node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/es/shared/node-entry.js:2128:30)
    at Object.error (file:///vite-vue3-admin/node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/es/shared/node-entry.js:24196:20)
    at Object.error (file:///vite-vue3-admin/node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/es/shared/node-entry.js:23390:42)
    at Object.transform (/vite-vue3-admin/node_modules/.pnpm/unplugin-vue-define-options@1.0.0_vue@3.2.47/node_modules/unplugin-vue-define-options/dist/chunk-TH6HNHQW.js:131:14)
    at plugin.transform (/vite-vue3-admin/node_modules/.pnpm/unplugin@1.3.1/node_modules/unplugin/dist/index.js:1194:25)
    at file:///vite-vue3-admin/node_modules/.pnpm/rollup@3.20.2/node_modules/rollup/dist/es/shared/node-entry.js:24395:40
 ELIFECYCLE  Command failed with exit code 1.
```